### PR TITLE
Set types property in package.json for type detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "lib/**/*",
     "index.js"
   ],
+  "types": "./lib/index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/huynhsamha/js-convert-case.git"


### PR DESCRIPTION
Typescript complained no types were found, but I saw there is a type declaration file. The issue is fixed when setting the types property in package.json